### PR TITLE
Add OPENAI_MODEL config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,12 @@ The system uses different OpenAI models for various tasks. Configure them in you
 - Entity extraction: `gpt-4o`
 - Trending analysis: `o3-mini`
 
+You can override the default model used across the application by setting the
+`OPENAI_MODEL` environment variable. For example:
+```bash
+export OPENAI_MODEL="gpt-4.1-mini"
+```
+
 ### Time Zone
 Default timezone is US Eastern Time. This can be configured in the application code.
 

--- a/news_grouping_app/analysis/company_extraction.py
+++ b/news_grouping_app/analysis/company_extraction.py
@@ -10,9 +10,10 @@ import logging
 from news_grouping_app.db.database import get_connection
 from news_grouping_app.llm_calls import call_gpt_api
 from news_grouping_app.utils import chunk_summaries, MAX_TOKEN_CHUNK
+from news_grouping_app.config import OPENAI_MODEL
 
 logger = logging.getLogger(__name__)
-MODEL = "o3-mini"  # or whichever model you prefer
+MODEL = OPENAI_MODEL  # default model can be overridden via env var
 
 
 def get_articles_missing_company_extraction(db_path="db/news.db"):

--- a/news_grouping_app/analysis/consistency_checker.py
+++ b/news_grouping_app/analysis/consistency_checker.py
@@ -12,9 +12,10 @@ from news_grouping_app.llm_calls import call_gpt_api
 from news_grouping_app.utils import chunk_summaries, MAX_TOKEN_CHUNK
 from news_grouping_app.analysis.context_builder import build_grouping_context, format_context_for_prompt
 from news_grouping_app.analysis.entity_extraction import get_entities_for_article
+from news_grouping_app.config import OPENAI_MODEL
 
 logger = logging.getLogger(__name__)
-MODEL = "o3-mini"  # or whichever model you prefer
+MODEL = OPENAI_MODEL  # default model can be overridden via env var
 
 
 def get_recent_groups_for_category(category, days=30, db_path="db/news.db"):

--- a/news_grouping_app/analysis/entity_extraction.py
+++ b/news_grouping_app/analysis/entity_extraction.py
@@ -10,9 +10,10 @@ import logging
 from news_grouping_app.db.database import get_connection, insert_entity, link_entity_to_article
 from news_grouping_app.llm_calls import call_gpt_api
 from news_grouping_app.utils import chunk_summaries, MAX_TOKEN_CHUNK
+from news_grouping_app.config import OPENAI_MODEL
 
 logger = logging.getLogger(__name__)
-MODEL = "o3-mini"  # or whichever model you prefer
+MODEL = OPENAI_MODEL  # default model can be overridden via env var
 
 # Increase the token chunk size for faster processing
 EXTRACTION_TOKEN_CHUNK = MAX_TOKEN_CHUNK * 1.5  # 50% larger chunks for extraction

--- a/news_grouping_app/analysis/group_merging.py
+++ b/news_grouping_app/analysis/group_merging.py
@@ -24,7 +24,8 @@ except ImportError as e:
     calculate_article_to_group_similarity = None
 
 logger = logging.getLogger(__name__)
-MERGE_LLM_MODEL = "o3-mini"  # Model for generating merged labels/desc
+from news_grouping_app.config import OPENAI_MODEL
+MERGE_LLM_MODEL = OPENAI_MODEL  # Model for generating merged labels/desc
 
 
 def _calculate_group_similarity(

--- a/news_grouping_app/analysis/trending_analysis.py
+++ b/news_grouping_app/analysis/trending_analysis.py
@@ -23,9 +23,10 @@ from news_grouping_app.utils import chunk_summaries, MAX_TOKEN_CHUNK
 # Import entity/context functions (these primarily read, should be okay)
 from news_grouping_app.analysis.entity_extraction import get_entities_for_article, get_trending_entities
 from news_grouping_app.analysis.context_builder import build_grouping_context, format_context_for_prompt
+from news_grouping_app.config import OPENAI_MODEL
 
 logger = logging.getLogger(__name__)
-MODEL = "o3-mini"  # or whichever model you prefer
+MODEL = OPENAI_MODEL  # default model can be overridden via env var
 
 
 def setup_trending_tables(db_path="db/news.db"):

--- a/news_grouping_app/analysis/two_phase_grouping.py
+++ b/news_grouping_app/analysis/two_phase_grouping.py
@@ -56,7 +56,8 @@ PREDEFINED_CATEGORIES = [
 ENABLE_LLM_MATCH_ASSESSMENT = (
     True  # Set to False to disable LLM checks for ambiguous cases
 )
-LLM_CHECK_MODEL = "o3-mini"
+from news_grouping_app.config import OPENAI_MODEL
+LLM_CHECK_MODEL = OPENAI_MODEL
 AMBIGUITY_ZONE_BELOW_THRESHOLD = 0.10  # How far below threshold triggers check
 AMBIGUITY_ZONE_ABOVE_THRESHOLD = 0.05  # How far above threshold triggers check
 MAX_SCORE_GAP_FOR_AMBIGUITY = 0.08  # If second best is this close, trigger check

--- a/news_grouping_app/app.py
+++ b/news_grouping_app/app.py
@@ -438,7 +438,8 @@ def test_grouping_prompt():
             return jsonify({"error": "No data provided"}), 400
         article_ids = data.get("articles", [])
         prompt_template = data.get("prompt_template", "")
-        model = data.get("model", "o3-mini")
+        from news_grouping_app.config import OPENAI_MODEL
+        model = data.get("model", OPENAI_MODEL)
 
         if not article_ids or not prompt_template:
             return jsonify({"error": "Missing 'articles' or 'prompt_template'"}), 400

--- a/news_grouping_app/config.py
+++ b/news_grouping_app/config.py
@@ -1,0 +1,6 @@
+import os
+
+# Use this environment variable to switch the OpenAI model globally.
+# For example, to use the gpt-4.1-mini model:
+#   export OPENAI_MODEL="gpt-4.1-mini"
+OPENAI_MODEL = os.getenv("OPENAI_MODEL", "o3-mini")

--- a/news_grouping_app/llm_calls.py
+++ b/news_grouping_app/llm_calls.py
@@ -5,7 +5,9 @@ import time
 import logging
 from openai import OpenAI
 
-MODEL = "o3-mini"
+from news_grouping_app.config import OPENAI_MODEL
+
+MODEL = OPENAI_MODEL
 MAX_RETRIES = 3
 REQUEST_TIMEOUT = 600
 


### PR DESCRIPTION
## Summary
- make the model used for OpenAI requests configurable via `OPENAI_MODEL` env var
- reference the new config from all analysis modules and the API endpoint
- document how to set the model
- add a comment in the config file showing how to set gpt-4.1-mini

## Testing
- `python -m py_compile $(git ls-files '*.py')`
