### PR TITLE
Add configurable schedule interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,13 @@ export OPENAI_MODEL="gpt-4.1-mini"
 ### Time Zone
 Default timezone is US Eastern Time. This can be configured in the application code.
 
+### Scheduling
+Control how often the pipeline runs by setting the `SCHEDULE_INTERVAL_MINUTES`
+environment variable. It defaults to `15` minutes if not specified:
+```bash
+export SCHEDULE_INTERVAL_MINUTES=30
+```
+
 ## Running the System
 
 ### Local Development

--- a/news_grouping_app/main.py
+++ b/news_grouping_app/main.py
@@ -175,9 +175,11 @@ def main():
         logger.exception("Error during initial run.")
 
     # Schedule regular runs
-    interval_minutes = 15  # Run every 15 minutes
+    interval_minutes = int(os.environ.get("SCHEDULE_INTERVAL_MINUTES", "15"))
     interval_seconds = interval_minutes * 60
-    logger.info(f"Setting up scheduler to run every {interval_minutes} minutes.")
+    logger.info(
+        f"Setting up scheduler to run every {interval_minutes} minutes."
+    )
 
     while True:
         try:


### PR DESCRIPTION
## Summary
- make run interval configurable via `SCHEDULE_INTERVAL_MINUTES`
- document the new environment variable in the Configuration section of the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`