### PR TITLE
Fix Docker build by ignoring frontend node_modules

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+frontend/node_modules
+build_log.txt
+build_log_local.txt
+.git
+__pycache__/
+*.py[cod]


### PR DESCRIPTION
## Summary
- add `.dockerignore` to avoid copying local `node_modules` during docker builds

## Testing
- `git status --short`