### PR TITLE
Fix entrypoint shebang

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Complete entrypoint.sh for news application
 
 echo "Starting application..."


### PR DESCRIPTION
## Summary
- use `/bin/sh` for the container entrypoint

## Testing
- `npm test --prefix frontend` *(fails: Missing script)*
- `python -m pytest` *(fails: No module named pytest)*