### PR TITLE
Fix entrypoint script path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,5 +47,5 @@ ENV OPENAI_API_KEY=""
 # Expose Flask port (8501)
 EXPOSE 8501
 
-# Use the entrypoint script
-CMD ["/app/entrypoint.sh"]
+# Use the entrypoint script directly with sh
+ENTRYPOINT ["/bin/sh", "/app/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Complete entrypoint.sh for news application
 
 echo "Starting application..."


### PR DESCRIPTION
## Summary
- run the entrypoint via `/bin/sh` so the path is always found

## Testing
- `npm test --prefix frontend` *(fails: Missing script)*
- `python -m pytest` *(fails: No module named pytest)*
