### PR TITLE
feat: add external entity identifiers and alias mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,11 +237,19 @@ The system performs three main analysis phases:
 - `articles` - Scraped articles with metadata
 - `two_phase_article_groups` - Article group definitions
 - `two_phase_article_group_memberships` - Article-to-group mappings
-- `entity_profiles` - Extracted entities
+- `entity_profiles` - Extracted entities with external IDs (`wiki_qid`) and JSON `aliases`
 - `article_entities` - Article-to-entity relationships
 - `trending_groups` - Trending topic definitions
 - `article_cves` - CVE mentions in articles
 - `cve_info` - Detailed CVE information
+
+If upgrading an existing database, run:
+
+```bash
+python -m news_grouping_app.wiki_qid_migration
+```
+
+to add these new fields and the unique index on `wiki_qid`.
 
 ## AI Models & Assistants
 

--- a/news_grouping_app/analysis/entity_extraction.py
+++ b/news_grouping_app/analysis/entity_extraction.py
@@ -156,12 +156,16 @@ def extract_entities_for_all_articles(api_key, db_path="db/news.db"):
                     description = entity.get("description", "")
                     relevance = float(entity.get("relevance", 1.0))
                     context = entity.get("context", "")
+                    wiki_qid = entity.get("qid") or entity.get("wiki_qid")
+                    aliases = entity.get("aliases", [])
 
                     # Insert or update the entity profile
                     entity_id = insert_entity(
                         entity_name=entity_name,
                         entity_type=entity_type,
                         description=description,
+                        wiki_qid=wiki_qid,
+                        aliases=aliases,
                         db_path=db_path,
                     )
 

--- a/news_grouping_app/analysis/trending_analysis.py
+++ b/news_grouping_app/analysis/trending_analysis.py
@@ -353,11 +353,18 @@ def save_trends(category, trends_data, db_path="db/news.db"):
                 for entity_data in key_entities:
                     entity_name = entity_data.get("name", "").strip()
                     entity_type = entity_data.get("type", "unknown").lower()
+                    wiki_qid = entity_data.get("qid") or entity_data.get("wiki_qid")
+                    aliases = entity_data.get("aliases", [])
                     if entity_name:
                         try:
                             # Pass the existing cursor
                             entity_id = insert_entity(
-                                entity_name, entity_type, db_path=db_path, cursor=cursor
+                                entity_name,
+                                entity_type,
+                                wiki_qid=wiki_qid,
+                                aliases=aliases,
+                                db_path=db_path,
+                                cursor=cursor,
                             )
                             if entity_id is None:  # Check if entity insertion failed
                                 logger.error(

--- a/news_grouping_app/main.py
+++ b/news_grouping_app/main.py
@@ -11,6 +11,9 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 # --- Database Setup & Migration ---
 from news_grouping_app.db.database import setup_database, DEFAULT_DB_PATH
 from news_grouping_app.datemigration import main as run_date_migration  # Keep date migration
+from news_grouping_app.wiki_qid_migration import (
+    main as run_wiki_qid_migration,
+)
 
 # --- Scrapers ---
 from news_grouping_app.scrapers import bleepingcomputer
@@ -141,6 +144,13 @@ def run_scrapers_and_analysis():
         logger.info("Date migration completed.")
     except Exception as e:
         logger.exception(f"Error during date migration: {e}")
+
+    logger.info("Ensuring wiki_qid field exists...")
+    try:
+        run_wiki_qid_migration()
+        logger.info("wiki_qid migration completed.")
+    except Exception as e:
+        logger.exception(f"Error during wiki_qid migration: {e}")
 
     # 4. Run Analysis Pipeline
     logger.info("--- Starting Analysis Pipeline ---")

--- a/news_grouping_app/wiki_qid_migration.py
+++ b/news_grouping_app/wiki_qid_migration.py
@@ -1,0 +1,41 @@
+"""
+Migration script to add external identifier fields to the entity_profiles table.
+
+Adds two new columns:
+  - wiki_qid: external Wikidata QID or Wikipedia page ID
+  - aliases: JSON encoded list of alternative names
+
+Also creates a unique index on wiki_qid to prevent duplicate entries.
+Run this once when upgrading an existing database.
+"""
+from pathlib import Path
+import sqlite3
+from news_grouping_app.db.database import DEFAULT_DB_PATH
+
+def column_exists(cur: sqlite3.Cursor, table: str, column: str) -> bool:
+    cur.execute(f"PRAGMA table_info({table})")
+    return any(row[1] == column for row in cur.fetchall())
+
+def index_exists(cur: sqlite3.Cursor, table: str, index_name: str) -> bool:
+    cur.execute(f"PRAGMA index_list({table})")
+    return any(row[1] == index_name for row in cur.fetchall())
+
+def main(db_path: Path = DEFAULT_DB_PATH) -> None:
+    db_path = Path(db_path)
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(db_path))
+    cur = conn.cursor()
+
+    if not column_exists(cur, "entity_profiles", "wiki_qid"):
+        cur.execute("ALTER TABLE entity_profiles ADD COLUMN wiki_qid TEXT")
+    if not column_exists(cur, "entity_profiles", "aliases"):
+        cur.execute("ALTER TABLE entity_profiles ADD COLUMN aliases TEXT")
+    if not index_exists(cur, "entity_profiles", "idx_entity_profiles_wiki_qid"):
+        cur.execute(
+            "CREATE UNIQUE INDEX idx_entity_profiles_wiki_qid ON entity_profiles(wiki_qid)"
+        )
+    conn.commit()
+    conn.close()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- extend `entity_profiles` with `wiki_qid` and JSON `aliases` fields
- add unique constraint on `wiki_qid` and merge aliases when inserting entities
- update entity extraction and trending analysis to pass through new metadata
- document new fields in README
- add migration script to create `wiki_qid` and `aliases` columns and unique index

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae3f32d5dc832f84996e076d3ae13a